### PR TITLE
Fix foreach key from width to weight

### DIFF
--- a/application/modules/spk_aktual/controllers/Spk_aktual.php
+++ b/application/modules/spk_aktual/controllers/Spk_aktual.php
@@ -2391,7 +2391,7 @@ class Spk_aktual extends Admin_Controller
 					foreach ($used[qtyaktual] as $key => $value) {
 						$ArrInsertStock[$key . $numb1]['qty'] = $value;
 					}
-					foreach ($used[width] as $key => $value) {
+					foreach ($used[weight] as $key => $value) {
 						$ArrInsertStock[$key . $numb1]['width'] = $value;
 					}
 					foreach ($used[totalaktual] as $key => $value) {


### PR DESCRIPTION
In application/modules/spk_aktual/controllers/Spk_aktual.php, change the foreach to iterate $used['weight'] instead of $used['width']. This fixes a typo in the data key so $ArrInsertStock entries receive the correct weight values when building the stock insert array.