### PR TITLE
Remove empty-checks before insert_batch calls

### DIFF
--- a/application/modules/retur_penjualan/controllers/Retur_penjualan.php
+++ b/application/modules/retur_penjualan/controllers/Retur_penjualan.php
@@ -42,6 +42,7 @@ class Retur_penjualan extends Admin_Controller
 		$this->template->title('Retur Penjualan');
 		$this->template->render('list_spkmarketing');
 	}
+
 	public function proses_incoming()
 	{
 
@@ -231,20 +232,20 @@ class Retur_penjualan extends Admin_Controller
 				}
 			}
 
-			if (!empty($detRetur)) {
-				// throw new Exception(''.print_r($detRetur).'');
-				$insert_detail_retur = $this->db->insert_batch('dt_returpenjualan', $detRetur);
-				if (!$insert_detail_retur) {
-					throw new Exception('Data detail retur gagal di input !');
-				}
+			// if (!empty($detRetur)) {
+			// throw new Exception(''.print_r($detRetur).'');
+			$insert_detail_retur = $this->db->insert_batch('dt_returpenjualan', $detRetur);
+			if (!$insert_detail_retur) {
+				throw new Exception('Data detail retur gagal di input !');
 			}
+			// }
 
-			if (!empty($arr_stock_retur)) {
-				$insert_stock_retur = $this->db->insert_batch('stock_material', $arr_stock_retur);
-				if (!$insert_stock_retur) {
-					throw new Exception('Data stock retur gagal di kembalikan !');
-				}
+			// if (!empty($arr_stock_retur)) {
+			$insert_stock_retur = $this->db->insert_batch('stock_material', $arr_stock_retur);
+			if (!$insert_stock_retur) {
+				throw new Exception('Data stock retur gagal di kembalikan !');
 			}
+			// }
 
 			$this->db->trans_commit();
 			$status	= array(


### PR DESCRIPTION
Commented out the surrounding if (!empty(...)) guards in proses_incoming so insert_batch is invoked for dt_returpenjualan and stock_material regardless of the emptiness checks. Also added a minor blank line after template render. Review callers to ensure $detRetur and $arr_stock_retur are prepared to avoid potential insert errors.