### PR TITLE
Remove price_sheet from stock_material select

### DIFF
--- a/application/modules/wt_invoicing/controllers/Wt_invoicing.php
+++ b/application/modules/wt_invoicing/controllers/Wt_invoicing.php
@@ -2726,7 +2726,7 @@ class Wt_invoicing extends Admin_Controller
 				$qty = 0;
 				$satuan = 'UM.0003';
 				if ($item_sheet->id_bentuk == 'B2000002') {
-					$get_qty_sheet = $this->db->select('a.qty_sheet, a.price_sheet')
+					$get_qty_sheet = $this->db->select('a.qty_sheet')
 						->from('stock_material a')
 						->join('dt_delivery_order_child b', 'b.lotno = a.lotno')
 						->join('tr_delivery_order c', 'c.id_delivery_order = b.id_delivery_order')


### PR DESCRIPTION
Update the query in application/modules/wt_invoicing/controllers/Wt_invoicing.php to only select a.qty_sheet from stock_material when joining dt_delivery_order_child and tr_delivery_order. This removes the unnecessary a.price_sheet column from the select list, reducing fetched data and avoiding use of an unused column.