### PR TITLE
Use exact width match in stock query

### DIFF
--- a/application/modules/delivery_order/controllers/Delivery_order.php
+++ b/application/modules/delivery_order/controllers/Delivery_order.php
@@ -545,7 +545,7 @@ class Delivery_order extends Admin_Controller
 		foreach ($dt as $dt) {
 			$loop++;
 			$id_category3	= $dt->id_material;
-			$lot			= $this->db->query("SELECT * FROM stock_material WHERE id_gudang = '3' AND id_category3='$id_category3' AND width >= $dt->width  AND no_surat like '%$nomor->no_surat%' AND status_do='OPN' ")->result();
+			$lot			= $this->db->query("SELECT * FROM stock_material WHERE id_gudang = '3' AND id_category3='$id_category3' AND width = $dt->width  AND no_surat like '%$nomor->no_surat%' AND status_do='OPN' ")->result();
 			// if(empty($lot)) {
 			// 	$lot			= $this->db->query("SELECT * FROM stock_material WHERE id_gudang = '3' AND id_category3='$id_category3' AND width = $dt->width AND no_surat like '%$nomor->no_surat%' AND status_do='OPN' ")->result();
 			// }


### PR DESCRIPTION
Modify the Delivery_order controller SQL to use '=' instead of '>=' for the width filter when querying stock_material (id_gudang = 3). This forces an exact width match for the selected id_category3 / no_surat / status_do criteria, preventing larger-width rows from being returned. Commented fallback logic is unchanged.